### PR TITLE
Switch decidim-term_customizer to the openpoke maintained fork

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem "decidim-alternative_landing", git: "https://github.com/Platoniq/decidim-mod
 gem "decidim-decidim_awesome", git: "https://github.com/decidim-ice/decidim-module-decidim_awesome", branch: "main"
 gem "decidim-goteo_oauth", git: "https://github.com/Platoniq/decidim-module-goteo_oauth", branch: "main"
 gem "decidim-social_crowdfunding", git: "https://github.com/Platoniq/decidim-module-social_crowdfunding", branch: "main"
-gem "decidim-term_customizer", git: "https://github.com/Platoniq/decidim-module-term_customizer", branch: "master"
+gem "decidim-term_customizer", github: "openpoke/decidim-module-term_customizer", branch: "release/0.29-stable"
 
 # ⚠️ MODULES UNDER DEVELOPMENT
 # gem "decidim-peertube", git: "https://github.com/Platoniq/decidim-module-peertube", branch: "main"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,15 +26,6 @@ GIT
       decidim-core (>= 0.29.0, < 0.30)
 
 GIT
-  remote: https://github.com/Platoniq/decidim-module-term_customizer
-  revision: 3da4973f52649534fa9cc2acaaa4d89176a19351
-  branch: master
-  specs:
-    decidim-term_customizer (0.29.0)
-      decidim-admin (~> 0.29.0)
-      decidim-core (~> 0.29.0)
-
-GIT
   remote: https://github.com/decidim-ice/decidim-module-decidim_awesome
   revision: 39b61b15e68e86fee193fa597c76a1392a8c5f8a
   branch: main
@@ -45,6 +36,15 @@ GIT
       decidim-core (>= 0.29.1, < 0.30)
       deface (>= 1.5)
       sassc (~> 2.3)
+
+GIT
+  remote: https://github.com/openpoke/decidim-module-term_customizer.git
+  revision: 12d3c4f09e0a136e3d5533966c0d983edbb02564
+  branch: release/0.29-stable
+  specs:
+    decidim-term_customizer (0.29.1)
+      decidim-admin (~> 0.29.0)
+      decidim-core (~> 0.29.0)
 
 GEM
   remote: https://rubygems.org/


### PR DESCRIPTION
## Summary
- Was pinned to Platoniq's own fork of `decidim-term_customizer` (branch `master`), which has fallen behind.
- `openpoke/decidim-module-term_customizer` actively maintains a `release/0.29-stable` branch matching this app's Decidim 0.29.4, so we can depend on their upkeep instead of patching our own fork.

## Verification
- `bundle install` resolves cleanly against the new source.
- `bin/rails decidim:upgrade` + `bin/rails db:migrate` against a fresh local database produce no new/changed migrations (same Decidim compat range, just a different upstream).

## Test plan
- [x] `bundle install`
- [x] `bin/rails decidim:upgrade`
- [x] `bin/rails db:migrate`
- [x] Smoke-test term customizer admin screens