### PR TITLE
Log rack-attack blocklist hits and report to AppSignal

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -59,7 +59,17 @@ class Rack::Attack
   end
 end
 
-ActiveSupport::Notifications.subscribe("throttle.rack_attack") do |_name, _start, _finish, _id, payload|
-  req = payload[:request]
-  Rails.logger.warn("[rack-attack] throttled #{req.ip} #{req.request_method} #{req.fullpath} UA=#{req.user_agent}")
+%w(throttle blocklist).each do |event|
+  ActiveSupport::Notifications.subscribe("#{event}.rack_attack") do |_name, _start, _finish, _id, payload|
+    req = payload[:request]
+    rule = req.env["rack.attack.matched"]
+
+    Rails.logger.warn(
+      "[rack-attack] #{event} #{rule} #{req.ip} #{req.request_method} #{req.fullpath} UA=#{req.user_agent}"
+    )
+
+    # rubocop:disable Rails/SkipsModelValidations
+    Appsignal.increment_counter("rack_attack", 1, event: event, rule: rule) if defined?(Appsignal)
+    # rubocop:enable Rails/SkipsModelValidations
+  end
 end


### PR DESCRIPTION
The subscriber in `config/initializers/rack_attack.rb` only listened to `throttle.rack_attack`, so blocked crawlers never showed up in the log. This subscribes to `blocklist` as well, adds the matched rule name to the log line, and increments an AppSignal counter.

Throttled and blocked requests are answered by Rack middleware and never reach a controller, so AppSignal records no transaction for them — the counter is what makes them visible. It no-ops on instances where AppSignal has no push API key.